### PR TITLE
Reset survey state between browser sessions and translate UI to Italian

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 window.CONFIG = {
-  SURVEY_TITLE: 'AI Dubbing Quality Survey',
+  SURVEY_TITLE: 'Questionario sulla qualità del doppiaggio IA',
   FORM_ENDPOINT: 'https://formspree.io/f/xrbanqkn',
   videos: [
     'https://example.com/videos/video01.mp4',

--- a/index.html
+++ b/index.html
@@ -1,22 +1,22 @@
 <!--
 README
-- Run locally by opening index.html in a modern browser with config.js in the same directory.
-- Publish to GitHub Pages by committing index.html, config.js, and links.html, pushing to your main branch, and enabling GitHub Pages for that branch or /docs folder.
-- Configure videos, SURVEY_TITLE, and FORM_ENDPOINT in config.js; update the values to match your project before sharing the survey.
-- The offline queue stores unsent responses per participant session in localStorage, retries automatically on each navigation, when the connection returns, and uses navigator.sendBeacon while closing the tab.
-- Share index.html directly with participants; no access code or uid parameter is required.
+- Esegui in locale aprendo index.html in un browser moderno con config.js nella stessa cartella.
+- Pubblica su GitHub Pages effettuando il commit di index.html, config.js e links.html, facendo push sul branch principale e attivando GitHub Pages per quel branch o per la cartella /docs.
+- Configura videos, SURVEY_TITLE e FORM_ENDPOINT in config.js; aggiorna i valori in base al tuo progetto prima di condividere il questionario.
+- La coda offline salva le risposte non inviate per ogni sessione del partecipante in localStorage, ritenta automaticamente a ogni navigazione, quando la connessione torna attiva, e usa navigator.sendBeacon alla chiusura della scheda.
+- Condividi direttamente index.html con i partecipanti; non è richiesto alcun codice di accesso o parametro uid.
 
-Formspree setup reminder
-- Create a form at https://formspree.io, copy the endpoint that looks like https://formspree.io/f/XXXXYYYY.
-- Paste that URL into CONFIG.FORM_ENDPOINT inside config.js. Formspree accepts JSON when the Accept header is set to application/json.
-- Add any notification rules you need from the Formspree dashboard.
+Promemoria per la configurazione di Formspree
+- Crea un form su https://formspree.io e copia l'endpoint simile a https://formspree.io/f/XXXXYYYY.
+- Incolla quell'URL in CONFIG.FORM_ENDPOINT dentro config.js. Formspree accetta JSON quando l'header Accept è impostato su application/json.
+- Aggiungi dal pannello di Formspree le regole di notifica di cui hai bisogno.
 -->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Survey</title>
+  <title>Questionario</title>
   <style>
     :root {
       color-scheme: dark;
@@ -438,11 +438,11 @@ Formspree setup reminder
         initializeDataAdapter();
 
         window.addEventListener('online', () => {
-          setStatus('Connection restored. Syncing any pending responses…', 'info');
+          setStatus('Connessione ripristinata. Sincronizzo le risposte in sospeso…', 'info');
           flushQueue();
         });
         window.addEventListener('offline', () => {
-          setStatus('You appear to be offline. Your answers will sync once you reconnect.', 'warning');
+          setStatus('Sembra che tu sia offline. Le risposte verranno sincronizzate quando ti ricollegherai.', 'warning');
         });
 
         window.addEventListener('pagehide', () => {
@@ -463,17 +463,17 @@ Formspree setup reminder
       function loadConfig() {
         const conf = window.CONFIG;
         if (!conf || typeof conf !== 'object') {
-          throw new Error('Configuration is missing. Please add config.js with a CONFIG object.');
+          throw new Error('Configurazione mancante. Aggiungi config.js con un oggetto CONFIG.');
         }
         const { videos, FORM_ENDPOINT, SURVEY_TITLE } = conf;
         if (!Array.isArray(videos) || videos.length !== 10 || !videos.every((v) => typeof v === 'string' && v.trim().length > 0)) {
-          throw new Error('CONFIG.videos must be an array of 10 video URLs.');
+          throw new Error('CONFIG.videos deve essere un array con 10 URL di video.');
         }
         if (typeof FORM_ENDPOINT !== 'string' || !FORM_ENDPOINT.trim()) {
-          throw new Error('CONFIG.FORM_ENDPOINT is required.');
+          throw new Error('CONFIG.FORM_ENDPOINT è obbligatorio.');
         }
         if (typeof SURVEY_TITLE !== 'string' || !SURVEY_TITLE.trim()) {
-          throw new Error('CONFIG.SURVEY_TITLE is required.');
+          throw new Error('CONFIG.SURVEY_TITLE è obbligatorio.');
         }
         return conf;
       }
@@ -561,6 +561,14 @@ Formspree setup reminder
         return trimmed.replace(/[^a-z0-9_-]/gi, '_');
       }
 
+      function getStateStorage() {
+        try {
+          return window.sessionStorage;
+        } catch (err) {
+          return null;
+        }
+      }
+
       function readUid(params) {
         if (!(params instanceof URLSearchParams)) {
           params = new URLSearchParams(window.location.search);
@@ -574,7 +582,11 @@ Formspree setup reminder
       }
 
       function loadStoredState() {
-        const raw = localStorage.getItem(storageKeys.state(state.uid));
+        const storage = getStateStorage();
+        if (!storage) {
+          return;
+        }
+        const raw = storage.getItem(storageKeys.state(state.uid));
         if (!raw) {
           return;
         }
@@ -590,7 +602,7 @@ Formspree setup reminder
             }
           }
         } catch (err) {
-          console.warn('Failed to load stored state', err);
+          console.warn('Impossibile caricare lo stato salvato', err);
         }
       }
 
@@ -617,10 +629,14 @@ Formspree setup reminder
           answers: state.answers,
           submitted: state.submitted
         };
+        const storage = getStateStorage();
+        if (!storage) {
+          return;
+        }
         try {
-          localStorage.setItem(storageKeys.state(state.uid), JSON.stringify(payload));
+          storage.setItem(storageKeys.state(state.uid), JSON.stringify(payload));
         } catch (err) {
-          console.warn('Unable to persist state', err);
+          console.warn('Impossibile salvare lo stato', err);
         }
       }
 
@@ -654,15 +670,15 @@ Formspree setup reminder
       }
 
       function renderError() {
-        const title = 'Configuration error';
+        const title = 'Errore di configurazione';
         const description = typeof state.error === 'string'
           ? state.error
-          : 'Please contact the organizer for assistance.';
+          : 'Contatta l\'organizzatore per ricevere assistenza.';
         appEl.innerHTML = `
           <section class="card error-view" aria-labelledby="error-title">
             <h1 id="error-title">${escapeHtml(title)}</h1>
             <p>${escapeHtml(description)}</p>
-            <p>If this problem persists, reach out to your study coordinator.</p>
+            <p>Se il problema persiste, contatta il coordinatore dello studio.</p>
           </section>
         `;
       }
@@ -672,9 +688,9 @@ Formspree setup reminder
           <section class="card welcome" aria-labelledby="welcome-title">
             <div class="logo" aria-hidden="true"><span>MFE</span></div>
             <h1 id="welcome-title">${escapeHtml(state.config.SURVEY_TITLE)}</h1>
-            <p>Thank you for helping us evaluate AI-dubbed videos. You will review ${state.config.videos.length} clips and answer two quick questions for each one.</p>
-            <p>Your progress is saved locally in this browser, so you can close and return to resume anytime.</p>
-            <button type="button" id="start-btn">Start</button>
+            <p>Grazie per aiutarci a valutare i video doppiati con l\'IA. Guarderai ${state.config.videos.length} clip e risponderai a due domande rapide per ciascuna.</p>
+            <p>I progressi restano salvati finch&eacute; questa scheda rimane aperta; se la chiudi, il questionario ripartir&agrave; dall\'inizio.</p>
+            <button type="button" id="start-btn">Inizia</button>
             <div class="status" data-role="status" aria-live="polite"></div>
           </section>
         `;
@@ -699,21 +715,21 @@ Formspree setup reminder
           <section class="card" aria-labelledby="step-title">
             <header class="top-bar">
               <h1 id="step-title">${escapeHtml(state.config.SURVEY_TITLE)}</h1>
-              <p class="progress">Video ${index + 1}/${total}</p>
+              <p class="progress">Video ${index + 1} di ${total}</p>
             </header>
             <div class="video-step">
               <div class="video-area">
                 <video controls preload="metadata">
                   <source src="${escapeAttribute(videoUrl)}" type="video/mp4">
-                  Your browser does not support the video tag.
+                  Il tuo browser non supporta il tag video.
                 </video>
               </div>
               <form class="questions" id="step-form">
                 <fieldset>
-                  <legend>Is this video AI generated?</legend>
+                  <legend>Questo video &egrave; generato dall\'IA?</legend>
                   <label class="option">
                     <input type="radio" name="is-ai" value="yes" ${isAi === 'yes' ? 'checked' : ''}>
-                    Yes
+                    S&igrave;
                   </label>
                   <label class="option">
                     <input type="radio" name="is-ai" value="no" ${isAi === 'no' ? 'checked' : ''}>
@@ -721,12 +737,12 @@ Formspree setup reminder
                   </label>
                 </fieldset>
                 <fieldset class="stars-fieldset">
-                  <legend>Rate the quality</legend>
-                  <div class="stars" role="radiogroup" aria-label="Quality rating from one to five stars">
+                  <legend>Valuta la qualit&agrave;</legend>
+                  <div class="stars" role="radiogroup" aria-label="Valutazione della qualit&agrave; da una a cinque stelle">
                     ${[1, 2, 3, 4, 5].map((value) => `
                       <div class="star-wrapper">
                         <input type="radio" id="quality-${value}" name="quality" value="${value}" ${quality === value ? 'checked' : ''}>
-                        <label for="quality-${value}" data-value="${value}" aria-label="${value} star${value > 1 ? 's' : ''}">★</label>
+                        <label for="quality-${value}" data-value="${value}" aria-label="${value} ${value === 1 ? 'stella' : 'stelle'}">★</label>
                       </div>
                     `).join('')}
                   </div>
@@ -734,8 +750,8 @@ Formspree setup reminder
               </form>
             </div>
             <div class="nav-buttons">
-              <button type="button" class="secondary" data-action="back">Back</button>
-              <button type="button" class="primary" data-action="next" disabled>Next</button>
+              <button type="button" class="secondary" data-action="back">Indietro</button>
+              <button type="button" class="primary" data-action="next" disabled>Avanti</button>
             </div>
             <div class="status" data-role="status" aria-live="polite"></div>
           </section>
@@ -795,16 +811,16 @@ Formspree setup reminder
         nextBtn.addEventListener('click', async () => {
           const answer = state.answers[index] || {};
           if (!isAnswerComplete(answer)) {
-            setStatus('Please answer both questions before continuing.', 'error');
+            setStatus('Rispondi a entrambe le domande prima di continuare.', 'error');
             updateNextState();
             return;
           }
           nextBtn.disabled = true;
-          nextBtn.textContent = 'Saving…';
+          nextBtn.textContent = 'Salvataggio in corso…';
           const record = buildRecord(index, answer);
           const result = await postRecord(record);
           if (!result.ok) {
-            setStatus('Your response is saved locally and will sync when possible.', 'warning');
+            setStatus('La tua risposta &egrave; salvata in locale e verr&agrave; sincronizzata appena possibile.', 'warning');
           }
           state.currentIndex = index + 1;
           state.started = true;
@@ -832,24 +848,24 @@ Formspree setup reminder
         const readyToSubmit = pending === 0 && allSent;
         const answersComplete = state.answers.filter((a) => isAnswerComplete(a)).length === total;
         const noteText = state.submitted
-          ? 'All responses were submitted successfully.'
+          ? 'Tutte le risposte sono state inviate con successo.'
           : readyToSubmit
-            ? 'All responses are synced. Submit to finalize.'
-            : 'Please keep this page open until all responses finish syncing.';
+            ? 'Tutte le risposte sono sincronizzate. Premi "Invia" per completare.'
+            : 'Mantieni questa pagina aperta finch&eacute; tutte le risposte non sono state sincronizzate.';
         appEl.innerHTML = `
           <section class="card" aria-labelledby="final-title">
             <h1 id="final-title">${escapeHtml(state.config.SURVEY_TITLE)}</h1>
-            <p>Great work! You have reviewed all ${total} videos.</p>
-            <ul class="summary-list" aria-label="Progress summary">
-              <li>Videos answered: ${answersComplete}/${total}</li>
-              <li>Responses waiting to sync: ${pending}</li>
+            <p>Ottimo lavoro! Hai esaminato tutti i ${total} video.</p>
+            <ul class="summary-list" aria-label="Riepilogo dei progressi">
+              <li>Video con risposta: ${answersComplete}/${total}</li>
+              <li>Risposte in attesa di sincronizzazione: ${pending}</li>
             </ul>
             <div class="final-actions">
-              <button type="button" class="primary" id="submit-btn" ${readyToSubmit && !state.submitted ? '' : 'disabled'}>${state.submitted ? 'Submitted' : 'Submit'}</button>
+              <button type="button" class="primary" id="submit-btn" ${readyToSubmit && !state.submitted ? '' : 'disabled'}>${state.submitted ? 'Inviato' : 'Invia'}</button>
               <span class="note">${noteText}</span>
             </div>
             <div class="status" data-role="status" aria-live="polite"></div>
-            ${state.submitted ? '<p class="status" data-type="success">Success! Your responses were submitted. You may close this tab.</p>' : ''}
+            ${state.submitted ? '<p class="status" data-type="success">Fatto! Le tue risposte sono state inviate. Puoi chiudere questa scheda.</p>' : ''}
           </section>
         `;
 
@@ -860,21 +876,21 @@ Formspree setup reminder
               return;
             }
             if (state.queueLength > 0 || !allAnswersPosted()) {
-              setStatus('We are still syncing your responses. Please wait until the queue is empty.', 'warning');
+              setStatus('Stiamo ancora sincronizzando le tue risposte. Attendi che la coda sia vuota.', 'warning');
               renderFinal();
               return;
             }
             submitBtn.disabled = true;
-            submitBtn.textContent = 'Submitting…';
+            submitBtn.textContent = 'Invio in corso…';
             const success = await flushQueue();
             if (success && allAnswersPosted()) {
               state.submitted = true;
               persistState();
-              setStatus('Success! Your responses were submitted. Thank you!', 'success');
+              setStatus('Fatto! Le tue risposte sono state inviate. Grazie!', 'success');
             } else {
               submitBtn.disabled = false;
-              submitBtn.textContent = 'Submit';
-              setStatus('We could not confirm the submission. Please check your connection and try again.', 'error');
+              submitBtn.textContent = 'Invia';
+              setStatus('Non &egrave; stato possibile confermare l\'invio. Controlla la connessione e riprova.', 'error');
             }
             renderFinal();
           });
@@ -929,11 +945,11 @@ Formspree setup reminder
 
       function postRecord(record) {
         if (!dataAdapter) {
-          return Promise.resolve({ ok: false, error: 'Data adapter unavailable.' });
+          return Promise.resolve({ ok: false, error: 'Adattatore dati non disponibile.' });
         }
         return dataAdapter.postRecord(record).then((response) => {
           if (response.ok) {
-            setStatus('Response synced.', 'success');
+            setStatus('Risposta sincronizzata.', 'success');
           }
           return response;
         });
@@ -945,7 +961,7 @@ Formspree setup reminder
         }
         return dataAdapter.flushQueue().then((allSent) => {
           if (allSent && state.queueLength === 0 && allAnswersPosted()) {
-            setStatus('All responses are synced.', 'success');
+            setStatus('Tutte le risposte sono sincronizzate.', 'success');
           }
           return allSent;
         });
@@ -974,7 +990,7 @@ Formspree setup reminder
         if (updated) {
           persistState();
           if (state.queueLength === 0 && allAnswersPosted()) {
-            setStatus('All responses are synced.', 'success');
+            setStatus('Tutte le risposte sono sincronizzate.', 'success');
           }
         }
       }
@@ -1028,11 +1044,11 @@ Formspree setup reminder
         }
         const total = state.config ? state.config.videos.length : 0;
         panel.innerHTML = `
-          <h3>Debug info</h3>
-          <p><strong>Session ID:</strong> ${escapeHtml(state.uid || 'n/a')}</p>
-          <p><strong>Index:</strong> ${state.currentIndex}/${total}</p>
-          <p><strong>Queue:</strong> ${state.queueLength}</p>
-          <button type="button" id="clear-debug">Clear local data</button>
+          <h3>Informazioni di debug</h3>
+          <p><strong>ID sessione:</strong> ${escapeHtml(state.uid || 'n/d')}</p>
+          <p><strong>Indice:</strong> ${state.currentIndex}/${total}</p>
+          <p><strong>Coda:</strong> ${state.queueLength}</p>
+          <button type="button" id="clear-debug">Cancella dati locali</button>
         `;
         const clearBtn = document.getElementById('clear-debug');
         if (clearBtn) {
@@ -1040,7 +1056,10 @@ Formspree setup reminder
             if (!state.uid) {
               return;
             }
-            localStorage.removeItem(storageKeys.state(state.uid));
+            const storage = getStateStorage();
+            if (storage) {
+              storage.removeItem(storageKeys.state(state.uid));
+            }
             localStorage.removeItem(storageKeys.queue(state.uid));
             window.location.reload();
           });
@@ -1188,7 +1207,7 @@ Formspree setup reminder
           try {
             localStorage.setItem(queueKey, JSON.stringify(queue));
           } catch (err) {
-            console.warn('Failed to persist queue', err);
+            console.warn('Impossibile salvare la coda', err);
           }
           notifyQueueChange();
         }
@@ -1217,12 +1236,12 @@ Formspree setup reminder
             try {
               payload = JSON.parse(text);
             } catch (err) {
-              console.warn('Unable to parse server response as JSON', err);
+              console.warn('Impossibile analizzare la risposta del server come JSON', err);
               payload = {};
             }
           }
           if (payload && (payload.ok === false || payload.error)) {
-            throw new Error(payload.error || 'Server error');
+            throw new Error(payload.error || 'Errore del server');
           }
           return payload;
         }
@@ -1235,9 +1254,9 @@ Formspree setup reminder
         return {
           postRecord: async (record) => {
             if (!CONFIG || !CONFIG.FORM_ENDPOINT) {
-              onError('The response server is not configured. Please retry later.');
+              onError('Il server per le risposte non è configurato. Riprova più tardi.');
               enqueue(record);
-              return { ok: false, error: 'Missing form endpoint' };
+              return { ok: false, error: 'Endpoint del modulo mancante' };
             }
             try {
               const response = await send(record);
@@ -1245,13 +1264,13 @@ Formspree setup reminder
               return { ok: true, response };
             } catch (err) {
               enqueue(record);
-              onError('Unable to reach the response server. Your answers will sync automatically when the connection is restored.');
+              onError('Impossibile raggiungere il server delle risposte. Le risposte verranno sincronizzate automaticamente quando la connessione verrà ripristinata.');
               return { ok: false, error: err instanceof Error ? err.message : String(err) };
             }
           },
           flushQueue: async () => {
             if (!CONFIG || !CONFIG.FORM_ENDPOINT) {
-              onError('The response server is not configured. Please retry later.');
+              onError('Il server per le risposte non è configurato. Riprova più tardi.');
               return false;
             }
             if (queue.length === 0) {
@@ -1272,7 +1291,7 @@ Formspree setup reminder
             queue = remaining;
             persistQueue();
             if (!allSent) {
-              onError('Some responses are still pending. They will be retried automatically.');
+              onError('Alcune risposte sono ancora in sospeso. Il tentativo verrà ripetuto automaticamente.');
             }
             return allSent;
           },

--- a/links.html
+++ b/links.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="it">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Survey Links</title>
+  <title>Link del questionario</title>
   <style>
     :root {
       color-scheme: dark;
@@ -82,11 +82,11 @@
 </head>
 <body>
   <main>
-    <h1>Survey Link</h1>
-    <p>This survey now uses open access. Share the link below with participants.</p>
+    <h1>Link del questionario</h1>
+    <p>Questo questionario &egrave; ora ad accesso aperto. Condividi il link qui sotto con i partecipanti.</p>
     <ul>
       <li>
-        <strong>Survey URL</strong>
+        <strong>URL del questionario</strong>
         <a id="survey-link" href="index.html">index.html</a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- use sessionStorage for survey progress so the questionnaire restarts when the tab is closed
- translate the participant UI, debug labels, and link helper page to Italian, including status/error messages
- localize the default survey title in config.js to Italian

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_b_68cd5ab50bd48320bc06d7558a600003