### PR TITLE
Center final submit button and update completion message

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,10 @@ Promemoria per la configurazione di Formspree
       flex-wrap: wrap;
     }
 
+    .final-actions .primary {
+      margin-left: 0;
+    }
+
     .final-view .status {
       margin-top: 2.5rem;
       text-align: center;
@@ -895,6 +899,9 @@ Promemoria per la configurazione di Formspree
             : 'Mantieni questa pagina aperta finch&eacute; tutte le risposte non sono state sincronizzate.';
         appEl.innerHTML = `
           <section class="card final-view" aria-labelledby="final-title">
+            <div class="logo">
+              <img src="MFE_-_MediaForEurope_Logo%20(1).png" alt="Logo MediaForEurope">
+            </div>
             <h1 id="final-title">${escapeHtml(state.config.SURVEY_TITLE)}</h1>
             <p class="final-message">Ottimo lavoro! Hai esaminato tutti i ${total} video.</p>
             ${noteText ? `<p class="final-note">${noteText}</p>` : ''}
@@ -902,7 +909,7 @@ Promemoria per la configurazione di Formspree
               <button type="button" class="primary" id="submit-btn" ${readyToSubmit && !state.submitted ? '' : 'disabled'}>${state.submitted ? 'Inviato' : 'Invia'}</button>
             </div>
             <div class="status" data-role="status" aria-live="polite"></div>
-            ${state.submitted ? '<p class="final-success">Fatto le risposte sono state salvate.</p>' : ''}
+            ${state.submitted ? '<p class="final-success">Fatto! Le risposte sono state salvate e puoi chiudere questa pagina. Grazie!</p>' : ''}
           </section>
         `;
 


### PR DESCRIPTION
## Summary
- center the final "Invia" button by overriding the primary button margin within the completion view
- add the MediaForEurope logo to the completion card to match the welcome page branding
- update the success message with clearer Italian instructions and a thank-you note

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cd66e655d48320a51841e76c8df20d