### PR TITLE
Reduce mobile spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,65 @@ Promemoria per la configurazione di Formspree
         margin-left: 0;
       }
     }
+
+    @media (max-width: 600px) {
+      body {
+        padding: 1.25rem 0.75rem 2rem;
+      }
+
+      .card {
+        padding: 1.65rem 1.25rem;
+        border-radius: 14px;
+      }
+
+      .logo {
+        margin-bottom: 1.5rem;
+        padding: 0.75rem;
+        border-radius: 22px;
+      }
+
+      .welcome h1 {
+        margin-bottom: 1.25rem;
+      }
+
+      .welcome p {
+        font-size: 1rem;
+        line-height: 1.6;
+        margin-bottom: 1.25rem;
+      }
+
+      .video-step {
+        margin-top: 1.75rem;
+        gap: 1.15rem;
+      }
+
+      video {
+        border-radius: 14px;
+      }
+
+      .questions {
+        padding: 1.35rem;
+        border-radius: 14px;
+      }
+
+      fieldset {
+        margin-bottom: 1.35rem;
+      }
+
+      .option {
+        margin-bottom: 0.7rem;
+        font-size: 1rem;
+      }
+
+      .nav-buttons {
+        margin-top: 1.75rem;
+        gap: 0.85rem;
+      }
+
+      .status {
+        margin-top: 1rem;
+      }
+    }
   </style>
   <script src="config.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- add a small-screen media query to reduce padding and margins on phones
- tighten typography and control spacing so the layout feels less airy on smartphones

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cd8041566483208aa329a97e1196c3